### PR TITLE
Sigma class multiplication

### DIFF
--- a/magpy/core/sigma.py
+++ b/magpy/core/sigma.py
@@ -117,7 +117,7 @@ class Sigma():
         """
         Return true if the operators have the same spins in the same sites.
         """
-        return self.spins == other.spins
+        return self.spins == other.spins and self.scale == other.scale
 
 
     def __neg__(self):

--- a/magpy/test/core/test_sigma.py
+++ b/magpy/test/core/test_sigma.py
@@ -27,17 +27,18 @@ def test_xyz_instantiation(instance, expected_spins):
     assert instance.spins == expected_spins
 
 
-@pytest.mark.parametrize("s1, s2, expected_spins",
+@pytest.mark.parametrize("s1, s2, expected_sigma",
     [
-        (Sigma(), Sigma(), {}),
-        (Sigma(x=1), Sigma(), {1 : 'x'}),
-        (Sigma(x=1), Sigma(y=2), {1 : 'x', 2 : 'y'}),
-        (Sigma(z=1), Sigma(x=1), {1 : 'zx'}),
-        (Sigma(x=1), Sigma(z=1), {1 : 'xz'}),
-        (Sigma(scale=0), Sigma(x=1), {})
+        (Sigma(), Sigma(), Sigma()),
+        (Sigma(x=1), Sigma(), Sigma(x=1)),
+        (Sigma(x=1), Sigma(y=2), Sigma(x=1, y=2)),
+        (Sigma(z=1), Sigma(x=1), Sigma(y=1, scale=1j)),
+        (Sigma(x=1), Sigma(z=1), Sigma(y=1, scale=-1j)),
+        (Sigma(x=1) * Sigma(y=1), Sigma(z=1), Sigma(scale=1j)),
+        (Sigma(scale=0), Sigma(x=1), Sigma(scale=0))
     ])
-def test_multiplication(s1, s2, expected_spins):
-    assert (s1 * s2).spins == expected_spins
+def test_multiplication(s1, s2, expected_sigma):
+    assert s1 * s2 == expected_sigma
 
 
 @pytest.mark.parametrize("scale, s1, expected_scale",


### PR DESCRIPTION
This improves the multiplication of Sigma instances by simplifying products of two Pauli matrices to another Pauli matrix.

To facilitate this, two private methods are added:

- Levi-Civita symbol - used in the function below. 
- Pauli matrix product - returns the resultant scalar coefficient and matrix for two Pauli matrices represented as characters (x, y, or z).

The product is calculated element-wise over the dictionaries within each Sigma instance. See the linked issue for why this works.

Closes #25 